### PR TITLE
Fixing Default Shortcode Attribute

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -52,7 +52,7 @@ class FontAwesome {
         extract( shortcode_atts( array(
                     'name'  => 'icon-wrench'
                 ), $params ) );
-        $icon = '<i class="'.$name.'">&nbsp;</i>';
+        $icon = '<i class="'. sanitize_html_class( $name ) .'">&nbsp;</i>';
 
         return $icon;
     }


### PR DESCRIPTION
It looks like you're [trying to set a default shortcode attribute value](http://codex.wordpress.org/Function_Reference/shortcode_atts) for the icon but then you don't use the default that you created.

Here's what the CMS looks like before the update:
![Screen Shot 2013-04-10 at 11 44 06 AM](https://f.cloud.github.com/assets/1065372/363257/581b0d3c-a1fe-11e2-8b5c-6967aa8eeb14.png)

Here's the output:
![Screen Shot 2013-04-10 at 11 44 30 AM](https://f.cloud.github.com/assets/1065372/363258/5e021894-a1fe-11e2-971f-31f5afd79801.png)

And after the fix everything is good. :)
![Screen Shot 2013-04-10 at 11 45 16 AM](https://f.cloud.github.com/assets/1065372/363261/670f44fc-a1fe-11e2-9241-af9eb350c217.png)
