### PR TITLE
Add size parameter

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -79,7 +79,12 @@ class FontAwesome {
 	}
 
 	public function setup_shortcode( $params ) {
-		return '<span class="fa fa-' . esc_attr( $params['name'] ) . '">&nbsp;</span>';
+		$icon_size = "";
+		if ($params['size']) {
+			$icon_size = "fa-" . $params['size'];
+		}
+		$code = '<span class="fa fa-' . esc_attr( $params['name'] ) . $icon_size . '">&nbsp;</span>';
+		return $code;
 	}
 
 	public function register_tinymce_plugin( $plugin_array ) {

--- a/plugin.php
+++ b/plugin.php
@@ -79,7 +79,7 @@ class FontAwesome {
 	}
 
 	public function setup_shortcode( $params ) {
-		return '<i class="fa fa-' . esc_attr( $params['name'] ) . '">&nbsp;</i>';
+		return '<span class="fa fa-' . esc_attr( $params['name'] ) . '">&nbsp;</span>';
 	}
 
 	public function register_tinymce_plugin( $plugin_array ) {


### PR DESCRIPTION
The Font Awesome framework supports a scaling of the icons through css: http://fortawesome.github.io/Font-Awesome/examples/

These pull requests include a simple, second parameter for the size of the icon. No validation or anything is performed to keep it simple.